### PR TITLE
Update EXT_OS_Task.json to fix invalidBodyFormat errors

### DIFF
--- a/resources/OperationalAPIView/Sourcing/EXT_OS_Task.json
+++ b/resources/OperationalAPIView/Sourcing/EXT_OS_Task.json
@@ -1,6 +1,4 @@
 {
-    "viewTemplateName": "EXT_OS_Task",
-    "type": "custom",
     "status": "published",
     "documentType": "Task",
     "selectAttributes": [


### PR DESCRIPTION
Fixes an error when creating the view template caused by the presence of `viewTemplateName` and `type` properties which aren't supported.
```
Response: 400 Bad Request
{
    "code": "invalidBodyFormat",
    "message": "Invalid body format. Invalid format :Unrecognized field \"viewTemplateName\" (class ariba.reportingapi.rest.entities.ViewParameters), not marked as ignorable (5 known properties: \"status\", \"selectAttributes\", \"documentType\", \"filterExpressions\", \"variant\"])\n at [Source: (String)\"{\"viewTemplateName\":\"EXT_OS_Task\",\"type\":\"custom\",\"status\":\"published\",\"documentType\":\"Task\",\"selectAttributes\":[\"Status\",\"InternalId\",\"Owner\",\"ParentPlan\",\"Title\",\"CreateDate\",\"EndDate\",\"TimeUpdated\",\"BeginDate\",\"TemplateObject\",\"TimeCreated\",\"Active\",\"ParentWorkspace\",\"EndDateTime\",\"RoundNumber\",\"DueDate\"],\"filterExpressions\":[{\"name\":\"updatedDateTo\",\"field\":\"TimeUpdated\",\"op\":\"<=\",\"defaultValue\":null},{\"name\":\"updatedDateFrom\",\"field\":\"TimeUpdated\",\"op\":\">\",\"defaultValue\":null}]}\"; line: 1, column: 22] (through reference chain: ariba.reportingapi.rest.entities.ViewParameters[\"viewTemplateName\"])"
}
```