### PR TITLE
Update package dependencies and Node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.0.0",
   "description": "BTP application for extracting procurement data",
   "private": true,
+  "engines": {
+    "node": "^22"
+  },
   "dependencies": {
     "@sap-cloud-sdk/connectivity": "^3",
     "@sap-cloud-sdk/http-client": "^3",
-    "@sap/cds": "^7",
-    "@sap/hana-client": "^2.18.24",
-    "@sap/xssec": "^3.3.2",
+    "@sap/cds": "^9",
+    "@cap-js/hana": "^2",
+    "@sap/xssec": "^4",
     "axios": "^0.27.2",
     "express": "^4.18.1",
     "flat": "^5.0.2",
@@ -21,8 +24,8 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@cap-js/sqlite": "^1",
-    "@sap/cds-dk": "^7"
+    "@cap-js/sqlite": "^2",
+    "@sap/cds-dk": "^9"
   },
   "cds": {
     "features": {


### PR DESCRIPTION
Fixing deployment failure due to node v18 got removed from buildpacks as is today 2026-04-20 #17 